### PR TITLE
Fix #6: Handle photo comments missing content.

### DIFF
--- a/tntapi.py
+++ b/tntapi.py
@@ -146,7 +146,13 @@ class API():
                     info = []
                     info.append(comment.find('a').contents[0]['alt']) # from
                     info.append(comment.find('div', {'class': 'time'}).contents[0]) # at
-                    info.append(comment.find('div', {'class': 'userContent'}).contents[0]) # comment
+
+                    userContent = comment.find('div', {'class': 'userContent'}).contents
+                    if len(userContent) > 0:
+                      info.append(userContent[0]) # comment
+                    else:
+                      info.append("") # empty comment
+
                     comm.append(info)
 
         return [picture, comm]


### PR DESCRIPTION
Some comments had no div.userContent (under unknown circumstances).

Fixed by adding an empty content (`""`) if `div.userContent` is missing.