### PR TITLE
Print traceback on unexpected exception.

### DIFF
--- a/20up.py
+++ b/20up.py
@@ -24,7 +24,7 @@ This program downloads all of the photos, comments, and
 friends' information of an specific user.
 """
 
-import os, sys, getpass
+import os, sys, getpass, traceback
 from tntwrapper import *
 
 version = '3.0'
@@ -230,6 +230,14 @@ if __name__ == '__main__':
             raw_input()
             break
         except Exception, e:
+            print '|'
+            print '-' * 60
+            print '|'
+            tb_lines = traceback.format_exc().splitlines()
+            for line in tb_lines:
+              print '| ' + line
+            print '|'
+            print '-' * 60
             print '|'
             print '| Ha ocurrido un error inesperado:', e
             print '|'


### PR DESCRIPTION
I figured this would be useful.

Prints a traceback when encountering an unexpected exception. It definitely helps when debugging, specially when users are trying to report an error. I think it's useful even for non-technical users, since I had to be given someone else's Tuenti credentials to be able to see the error happening myself, while a traceback would've sufficed. A traceback is probably confusing for regular users, but so is `list index out of range` (or any other exception... also, not very helpful to debug).

I made formatting similar to the rest of the program (`| ` at start of line, `-----` as separator).

Of course, feel free to dismiss this pull request if you disagree :)