### PR TITLE
Added gitignore and fixed download problem

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+*pyc
+fotos/

--- a/tntapi.py
+++ b/tntapi.py
@@ -133,6 +133,7 @@ class API():
         self.driver.get(linkAlbum)
         
         element = WebDriverWait(self.driver, 10).until(EC.presence_of_element_located((By.ID, INFOS['ulFirstPic'])))
+        sleep(3)
         
         html = self.driver.page_source
         soup = BeautifulSoup(html, 'html.parser')


### PR DESCRIPTION
**English version further down**

¡Hola!
Cuando estaba intentando descargar las fotos de mi cuenta no funcionaba, he visto que no funcionaba, enumeraba bien los álbumes pero luego no descargaba las fotos del álbum que tocaba, quedando el backup incompleto y desorganizado. El problema se debía a que en la función getFirstPicture() buscaba la primera foto del álbum antes de que hubiera cargado en el explorador la web. Lo he solucionado con un pequeño sleep().
También he añadido un fichero .gitignore para que no se suban los ficheros .pyc ni la carpeta donde se guardan las fotos.

Saludos,
Alejandro Suarez
**English version**
Hi!
When I was trying to download all the photos from my account I have found the it doesn't work, downloading wrong photos in each album. The problem was in the getFirstPicture() function, it tried to find the the first photo before the web was charged in the selenium browser. I fifed it with a delay.
I also added a .gitignore file in order to avoid commiting pyc files and the "fotos" folder.

Best regards,
Alejandro Suarez
